### PR TITLE
Fix broken version stapling syntax on watchfiles requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ python-multipart==0.0.6
 # API and Communication
 requests==2.31.0
 python-dotenv==1.0.0
-watchfiles=1.0.4
+watchfiles==1.0.4
 
 # Audio Processing
 numpy==1.24.0


### PR DESCRIPTION
Simple typo fix that adjusts the watchfiles stapling to use == instead of =, since it makes pip upset.