### PR TITLE
Add docker compose and llama-cpp-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*.env
+models/
+*.gguf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.env
+__pycache__/
+.venv/
+venv/
+models/
+*.gguf

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,47 @@
+FROM ubuntu:22.04
+
+# Set non-interactive frontend
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Python and other dependencies
+RUN apt-get update && apt-get install -y \
+    python3.10 \
+    python3-pip \
+    python3-venv \
+    libsndfile1 \
+    ffmpeg \
+    portaudio19-dev \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user and set up directories
+RUN useradd -m -u 1001 appuser && \
+    mkdir -p /app/outputs /app && \
+    chown -R appuser:appuser /app
+
+USER appuser
+WORKDIR /app
+
+# Copy dependency files
+COPY --chown=appuser:appuser requirements.txt ./requirements.txt
+
+# Create and activate virtual environment
+RUN python3 -m venv /app/venv
+ENV PATH="/app/venv/bin:$PATH"
+
+# Install PyTorch with CUDA support and other dependencies
+RUN pip3 install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124 && \
+    pip3 install --no-cache-dir -r requirements.txt
+
+# Copy project files
+COPY --chown=appuser:appuser . .
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app \
+    USE_GPU=true
+
+# Expose the port
+EXPOSE 5005
+
+# Run FastAPI server with uvicorn
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5005", "--workers", "1"]

--- a/README.md
+++ b/README.md
@@ -83,10 +83,14 @@ Orpheus-FastAPI/
 The docker compose file orchestrates the Orpheus-FastAPI for audio and a llama.cpp inference server for the base model token generation. The GGUF model is downloaded with the model-init service.
 
 ```bash
+cp .env.example .env # Nothing needs to be changed, but the file is required
+```
+
+```bash
 docker compose up --build
 ```
 
-### Installation
+### FastAPI Service Native Installation
 
 1. Clone the repository:
 ```bash

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Listen to sample outputs with different voices and emotions:
 ```
 Orpheus-FastAPI/
 ├── app.py                # FastAPI server and endpoints
+├── docker-compose.yml    # Docker compose configuration
+├── Dockerfile.gpu        # GPU-enabled Docker image
 ├── requirements.txt      # Dependencies
 ├── static/               # Static assets (favicon, etc.)
 ├── outputs/              # Generated audio files
@@ -74,7 +76,15 @@ Orpheus-FastAPI/
 
 - Python 3.8-3.11 (Python 3.12 is not supported due to removal of pkgutil.ImpImporter)
 - CUDA-compatible GPU (recommended: RTX series for best performance)
-- Separate LLM inference server running the Orpheus model (e.g., LM Studio or llama.cpp server)
+- Using docker compose or separate LLM inference server running the Orpheus model (e.g., LM Studio or llama.cpp server)
+
+### 🐳 Docker compose
+
+The docker compose file orchestrates the Orpheus-FastAPI for audio and a llama.cpp inference server for the base model token generation. The GGUF model is downloaded with the model-init service.
+
+```bash
+docker compose up --build
+```
 
 ### Installation
 
@@ -271,7 +281,7 @@ You can easily integrate this TTS solution with [OpenWebUI](https://github.com/o
 
 ### External Inference Server
 
-This application requires a separate LLM inference server running the Orpheus model. You can use:
+This application requires a separate LLM inference server running the Orpheus model. For easy setup, use Docker Compose, which automatically handles this for you. Alternatively, you can use:
 
 - [GPUStack](https://github.com/gpustack/gpustack) - GPU optimised LLM inference server (My pick) - supports LAN/WAN tensor split parallelisation
 - [LM Studio](https://lmstudio.ai/) - Load the GGUF model and start the local server
@@ -291,9 +301,9 @@ The inference server should be configured to expose an API endpoint that this Fa
 
 ### Environment Variables
 
-You can configure the system using environment variables or a `.env` file:
+Configure in docker compose, if using docker. Not using docker; create a `.env` file:
 
-- `ORPHEUS_API_URL`: URL of the LLM inference API (tts_engine/inference.py)
+- `ORPHEUS_API_URL`: URL of the LLM inference API (default in Docker: http://llama-cpp-server:5006/v1/completions)
 - `ORPHEUS_API_TIMEOUT`: Timeout in seconds for API requests (default: 120)
 - `ORPHEUS_MAX_TOKENS`: Maximum tokens to generate (default: 8192)
 - `ORPHEUS_TEMPERATURE`: Temperature for generation (default: 0.6)
@@ -301,6 +311,7 @@ You can configure the system using environment variables or a `.env` file:
 - `ORPHEUS_SAMPLE_RATE`: Audio sample rate in Hz (default: 24000)
 - `ORPHEUS_PORT`: Web server port (default: 5005)
 - `ORPHEUS_HOST`: Web server host (default: 0.0.0.0)
+- `ORPHEUS_MODEL_NAME`: Model name for inference server
 
 The system now supports loading environment variables from a `.env` file in the project root, making it easier to configure without modifying system-wide environment settings. See `.env.example` for a template.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+services:
+  orpheus-fastapi:
+    container_name: orpheus-fastapi
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+    ports:
+      - "5005:5005"
+    environment:
+      # Server connection settings
+      - ORPHEUS_API_URL=http://llama-cpp-server:5006/v1/completions
+      - ORPHEUS_API_TIMEOUT=120 # You should scale this value based on max tokens and your inference speed
+      # Generation parameters
+      - ORPHEUS_MAX_TOKENS=8192 # If you want longer completions, increase this value
+      - ORPHEUS_TEMPERATURE=0.6
+      - ORPHEUS_TOP_P=0.9
+      - ORPHEUS_SAMPLE_RATE=24000
+      - ORPHEUS_MODEL_NAME=Orpheus-3b-FT-Q2_K.gguf # (Change here requires changes below)
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped
+    depends_on:
+      - llama-cpp-server
+
+  llama-cpp-server:
+    image: ghcr.io/ggml-org/llama.cpp:server-cuda
+    ports:
+      - "5006:5006"
+    volumes:
+      - ./models:/models
+    depends_on:
+      model-init:
+        condition: service_completed_successfully
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped
+    command: -m /models/Orpheus-3b-FT-Q2_K.gguf --port 5006 --host 0.0.0.0 --n-gpu-layers 29
+
+  model-init:
+    image: curlimages/curl:latest
+    user: ${UID}:${GID}
+    volumes:
+      - ./models:/app/models
+    working_dir: /app
+    command: >
+      sh -c '
+      if [ ! -f /app/models/Orpheus-3b-FT-Q2_K.gguf ]; then
+        echo "Downloading model file..."
+        wget -P /app/models https://huggingface.co/lex-au/Orpheus-3b-FT-Q2_K.gguf/resolve/main/Orpheus-3b-FT-Q2_K.gguf
+      else
+        echo "Model file already exists"
+      fi'
+    restart: "no"
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,10 @@ services:
       dockerfile: Dockerfile.gpu
     ports:
       - "5005:5005"
+    env_file:
+      - .env
     environment:
-      # Server connection settings
       - ORPHEUS_API_URL=http://llama-cpp-server:5006/v1/completions
-      - ORPHEUS_API_TIMEOUT=120 # You should scale this value based on max tokens and your inference speed
-      # Generation parameters
-      - ORPHEUS_MAX_TOKENS=8192 # If you want longer completions, increase this value
-      - ORPHEUS_TEMPERATURE=0.6
-      - ORPHEUS_TOP_P=0.9
-      - ORPHEUS_SAMPLE_RATE=24000
-      - ORPHEUS_MODEL_NAME=Orpheus-3b-FT-Q2_K.gguf # (Change here requires changes below)
     deploy:
       resources:
         reservations:
@@ -25,7 +19,8 @@ services:
               capabilities: [gpu]
     restart: unless-stopped
     depends_on:
-      - llama-cpp-server
+      llama-cpp-server:
+        condition: service_started
 
   llama-cpp-server:
     image: ghcr.io/ggml-org/llama.cpp:server-cuda
@@ -33,6 +28,8 @@ services:
       - "5006:5006"
     volumes:
       - ./models:/models
+    env_file:
+      - .env
     depends_on:
       model-init:
         condition: service_completed_successfully
@@ -44,7 +41,14 @@ services:
               count: all
               capabilities: [gpu]
     restart: unless-stopped
-    command: -m /models/Orpheus-3b-FT-Q2_K.gguf --port 5006 --host 0.0.0.0 --n-gpu-layers 29
+    command: >
+      -m /models/${ORPHEUS_MODEL_NAME}
+      --port 5006 
+      --host 0.0.0.0 
+      --n-gpu-layers 29
+      --ctx-size ${ORPHEUS_MAX_TOKENS}
+      --n-predict ${ORPHEUS_MAX_TOKENS}
+      --rope-scaling linear
 
   model-init:
     image: curlimages/curl:latest
@@ -54,9 +58,9 @@ services:
     working_dir: /app
     command: >
       sh -c '
-      if [ ! -f /app/models/Orpheus-3b-FT-Q2_K.gguf ]; then
+      if [ ! -f /app/models/${ORPHEUS_MODEL_NAME} ]; then
         echo "Downloading model file..."
-        wget -P /app/models https://huggingface.co/lex-au/Orpheus-3b-FT-Q2_K.gguf/resolve/main/Orpheus-3b-FT-Q2_K.gguf
+        wget -P /app/models https://huggingface.co/lex-au/${ORPHEUS_MODEL_NAME}/resolve/main/${ORPHEUS_MODEL_NAME}
       else
         echo "Model file already exists"
       fi'


### PR DESCRIPTION
- Add Dockerfile for building Orpheus-FastAPI image on GPUs
- Docker compose orchestration with  llama-cpp-server (w/ CUDA enabled) and a model downloader
- Uses the `.env` file for the model and generation variables

> Requires [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html), which can be added to WSL2 for Windows

Changed:
- Only changed the `ensure_env_file_exists()` to prevent it from overriding system OS environment variables (which are applied in the Docker compose file), it still creates a `.env` for users not using Docker.
- I updated the README some, but you may want to reflect more changes (tried to keep changes minimal)
- Added `.gitignore` and `.dockerignore` (these are needed)

> I can't test it with truly good realtime performance because I just have a GTX 1080 8gb and it seems like that is not enough for realtime, but it is working well for me still.