### PR TITLE
FIx for Command line in docker compose is not working on windows

### DIFF
--- a/docker-compose-cpu.yaml
+++ b/docker-compose-cpu.yaml
@@ -28,17 +28,7 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
     command: >
-      -m /models/${ORPHEUS_MODEL_NAME}
-      --host 0.0.0.0
-      --port 5006
-      --ctx-size ${ORPHEUS_MAX_TOKENS}
-      --n-predict ${ORPHEUS_MAX_TOKENS}
-      --threads ${LLAMA_CPU_THREADS:-6}
-      --threads-batch ${LLAMA_CPU_THREADS:-6}
-      --rope-scaling linear
-      --no-mmap
-      --no-slots
-      --no-webui
+      "-m /models/${ORPHEUS_MODEL_NAME} --host 0.0.0.0 --port 5006 --ctx-size ${ORPHEUS_MAX_TOKENS} --n-predict ${ORPHEUS_MAX_TOKENS} --threads ${LLAMA_CPU_THREADS:-6} --threads-batch ${LLAMA_CPU_THREADS:-6} --rope-scaling linear --no-mmap --no-slots --no-webui"
   model-init:
     image: curlimages/curl:latest
     user: ${UID}:${GID}

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -42,13 +42,7 @@ services:
               capabilities: [gpu]
     restart: unless-stopped
     command: >
-      -m /models/${ORPHEUS_MODEL_NAME}
-      --port 5006 
-      --host 0.0.0.0 
-      --n-gpu-layers 29
-      --ctx-size ${ORPHEUS_MAX_TOKENS}
-      --n-predict ${ORPHEUS_MAX_TOKENS}
-      --rope-scaling linear
+      "-m /models/${ORPHEUS_MODEL_NAME} --port 5006 --host 0.0.0.0 --n-gpu-layers 29 --ctx-size ${ORPHEUS_MAX_TOKENS} --n-predict ${ORPHEUS_MAX_TOKENS} --rope-scaling linear"
 
   model-init:
     image: curlimages/curl:latest


### PR DESCRIPTION
The command in the docker-compose files was updated to be a single string enclosed in quotes. This ensures that the entire command is interpreted correctly as a single command line string, which is necessary to avoid parsing errors in Docker Compose.

Before: The command was split across multiple lines without quotes, which could lead to parsing issues.